### PR TITLE
Solve coding problems

### DIFF
--- a/src/trello2md.py
+++ b/src/trello2md.py
@@ -9,6 +9,7 @@ import sys
 import argparse
 import json
 import re
+import codecs
 
 
 # a url in a line (obligatory starting with the protocol part)
@@ -136,7 +137,7 @@ def main():
 
     # load infile to 'data'
     try:
-        with open(args.inputfile, 'r') as inf:
+        with open(args.inputfile, 'r', encoding="utf8") as inf:
             data = json.load(inf)
     except IOError as e:
         sys.exit('I/O error({0}): {1}'.format(e.errno, e.strerror))
@@ -178,7 +179,7 @@ def main():
             outputfile += '.md'
 
     try:
-        with open(outputfile, 'w') as of:
+        with open(outputfile, 'w', encoding="utf8") as of:
             of.write(''.join(markdown))
 
         print('Sucessfully translated to "{0}"!'.format(outputfile))


### PR DESCRIPTION
Solve the bug for "UnicodeDecodeError: 'gbk' codec can't decode byte 0xa6 in position 3462: illegal
 multibyte sequence" when non-Latin scripts are used